### PR TITLE
fix(permissions): add read access for all roles on Owl Theme Settings

### DIFF
--- a/owl_theme/owl_theme/doctype/owl_theme_settings/owl_theme_settings.json
+++ b/owl_theme/owl_theme/doctype/owl_theme_settings/owl_theme_settings.json
@@ -182,7 +182,7 @@
  "issingle": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-01-19 14:50:37.175277",
+ "modified": "2025-02-16 08:56:30.114016",
  "modified_by": "Administrator",
  "module": "Owl Theme",
  "name": "Owl Theme Settings",
@@ -198,6 +198,10 @@
    "select": 1,
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "sort_field": "creation",


### PR DESCRIPTION
 This PR fixes an issue where non-administrator users encounter a permission error when logging in:  

> _"You need the 'read' permission on Owl Theme Settings to perform this action."_

Since the theme should be accessible to all users, this change ensures that all roles have **read access** to the `Owl Theme Settings` doctype without requiring administrator privileges.  

## Changes Made  
✅ Added **read permission** for all roles in the `Owl Theme Settings` doctype.   

## Steps to Reproduce (Before Fix)  
1. Log in with a non-administrator account.  
2. Try to access a page where the theme is applied.  
3. Observe the permission error.  

## Expected Behavior (After Fix)  
✔ Non-admin users can log in and access the theme without errors.    

## Testing Done  
- ✅ Tested with multiple user roles to confirm the issue is resolved.  
- ✅ Verified that only **read** access is granted, preventing unwanted modifications.  

## Linked Issue  
Fixes **#1**.  

---

### **Next Steps**  
- Please review and let me know if any changes are needed.  
- If approved, this PR is ready to be merged.  
